### PR TITLE
Add line item with arrowhead toggle support

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,7 +1,15 @@
 from PySide6 import QtCore, QtGui
 
 PALETTE_MIME = "application/x-drawsvg-shape"
-SHAPES = ("Rectangle", "Ellipse", "Circle", "Triangle", "Line", "Text")
+SHAPES = (
+    "Rectangle",
+    "Ellipse",
+    "Circle",
+    "Triangle",
+    "Line",
+    "Arrow",
+    "Text",
+)
 
 DEFAULTS = {
     "Rectangle": (160.0, 100.0),   # w, h
@@ -9,6 +17,7 @@ DEFAULTS = {
     "Circle":    (100.0, 100.0),   # diameter, diameter
     "Triangle":  (160.0, 100.0),   # w, h
     "Line":      (150.0, 0.0),     # length, (unused)
+    "Arrow":     (150.0, 0.0),     # length, (unused)
     "Text":      (100.0, 30.0),    # placeholder bbox
 }
 


### PR DESCRIPTION
## Summary
- add Arrow shape to palette and line item with start/end arrowheads
- enable toggling arrowheads from context menu and cloning of arrow lines
- export/import arrow lines using drawsvg markers and paths

## Testing
- `python -m py_compile src/constants.py src/items.py src/canvas_view.py src/export_drawsvg.py src/import_drawsvg.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb2eef01d883208f01e9ec915490c1