### PR TITLE
Ensure arrows snap to grid by default

### DIFF
--- a/src/canvas_view.py
+++ b/src/canvas_view.py
@@ -104,6 +104,14 @@ class CanvasView(QtWidgets.QGraphicsView):
         y = scene_pos.y()
 
         w, h = DEFAULTS[shape]
+        mods = event.keyboardModifiers()
+        if not mods & QtCore.Qt.KeyboardModifier.AltModifier:
+            size = self._grid_size
+            x = round(x / size) * size
+            y = round(y / size) * size
+            if shape in ("Line", "Arrow"):
+                w = round(w / size) * size
+
         if shape == "Rectangle":
             item = RectItem(x, y, w, h)
         elif shape in ("Circle", "Ellipse"):

--- a/src/items.py
+++ b/src/items.py
@@ -374,8 +374,11 @@ class LineHandle(QtWidgets.QGraphicsEllipseItem):
 
     def mouseMoveEvent(self, event: QtWidgets.QGraphicsSceneMouseEvent):
         parent = self.parentItem()
+        mods = event.modifiers()
         if self._endpoint == "start":
             new_start = event.scenePos()
+            if not mods & QtCore.Qt.KeyboardModifier.AltModifier:
+                new_start = snap_to_grid(parent, new_start)
             end_scene = self._line_end_scene
             parent.setPos(new_start)
             parent.setLine(
@@ -387,6 +390,8 @@ class LineHandle(QtWidgets.QGraphicsEllipseItem):
         else:  # end handle
             start_scene = self._line_start_scene
             new_end = event.scenePos()
+            if not mods & QtCore.Qt.KeyboardModifier.AltModifier:
+                new_end = snap_to_grid(parent, new_end)
             parent.setPos(start_scene)
             parent.setLine(
                 0.0,


### PR DESCRIPTION
## Summary
- Snap arrow endpoints to grid when placed on canvas
- Allow temporarily disabling snapping with Alt while dragging arrow handles

## Testing
- `python -m py_compile src/items.py src/canvas_view.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb33652f348320af7b67244f42f0f4