### PR TITLE
Handle horizontal wheel delta for Alt zoom

### DIFF
--- a/src/canvas_view.py
+++ b/src/canvas_view.py
@@ -277,7 +277,10 @@ class CanvasView(QtWidgets.QGraphicsView):
             self.setTransformationAnchor(
                 QtWidgets.QGraphicsView.ViewportAnchor.AnchorUnderMouse
             )
-            factor = 1.2 if event.angleDelta().y() > 0 else 1 / 1.2
+            delta = event.angleDelta().y()
+            if delta == 0:
+                delta = event.angleDelta().x()
+            factor = 1.2 if delta > 0 else 1 / 1.2
             self.scale(factor, factor)
             self.setTransformationAnchor(anchor)
             event.accept()

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -28,7 +28,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._build_menu()
         self.statusBar().showMessage(
-            "Tip: Ctrl+drag duplicates selected objects, Alt+mouse wheel rotates"
+            "Tip: Ctrl+drag duplicates selected objects, Alt+mouse wheel zooms"
         )
 
     def _build_menu(self):


### PR DESCRIPTION
## Summary
- Fix Alt+mouse wheel zoom direction by considering horizontal delta when vertical movement is zero
- Update status bar tip to reflect Alt+mouse wheel zoom

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb45f36840832087e89da2cb5500dd