### PR TITLE
Fix middle mouse canvas panning

### DIFF
--- a/src/canvas_view.py
+++ b/src/canvas_view.py
@@ -178,7 +178,10 @@ class CanvasView(QtWidgets.QGraphicsView):
         if self._panning:
             delta = event.position() - self._pan_start
             self._pan_start = event.position()
-            self.translate(delta.x(), delta.y())
+            hbar = self.horizontalScrollBar()
+            vbar = self.verticalScrollBar()
+            hbar.setValue(hbar.value() - int(delta.x()))
+            vbar.setValue(vbar.value() - int(delta.y()))
             event.accept()
             return
         if getattr(self, "_dup_source", None):


### PR DESCRIPTION
## Summary
- pan the canvas using scrollbars when holding the middle mouse button for smoother movement

## Testing
- `python -m py_compile src/canvas_view.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb4787b1e48320989ce5f641a522e1