### PR TITLE
feat: expand canvas dynamically

### DIFF
--- a/src/canvas_view.py
+++ b/src/canvas_view.py
@@ -44,6 +44,9 @@ class CanvasView(QtWidgets.QGraphicsView):
         self.setDragMode(QtWidgets.QGraphicsView.DragMode.RubberBandDrag)
         self.setAcceptDrops(True)
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
+        self.setViewportUpdateMode(
+            QtWidgets.QGraphicsView.ViewportUpdateMode.FullViewportUpdate
+        )
 
         scene = QtWidgets.QGraphicsScene(self)
         self._scene_padding = 200

--- a/src/canvas_view.py
+++ b/src/canvas_view.py
@@ -106,6 +106,8 @@ class CanvasView(QtWidgets.QGraphicsView):
             new_rect = combined.adjusted(-padding, -padding, padding, padding)
         if new_rect != scene.sceneRect():
             scene.setSceneRect(new_rect)
+            # ensure newly exposed areas are repainted so drag handles don't leave trails
+            self.viewport().update()
 
     # --- Drag and drop from the palette ---
     def dragEnterEvent(self, event: QtGui.QDragEnterEvent):


### PR DESCRIPTION
## Summary
- make canvas scene adapt to its content and current viewport with a 200px margin
- resize scene when items are added, cleared or after zooming

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd085c508832086e3dab3fb85615e