### PR TITLE
fix: import LineItem in export_drawsvg

### DIFF
--- a/src/export_drawsvg.py
+++ b/src/export_drawsvg.py
@@ -1,6 +1,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from constants import SHAPES
+from items import LineItem
 
 
 def export_drawsvg_py(scene: QtWidgets.QGraphicsScene, parent: QtWidgets.QWidget | None = None):


### PR DESCRIPTION
## Summary
- import missing LineItem class for exporting line and arrow shapes

## Testing
- `python -m py_compile src/export_drawsvg.py`
- `python -m py_compile src/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc80b2ddcc832097685797e525c819