### PR TITLE
Handle negative origins during export/import

### DIFF
--- a/src/export_drawsvg.py
+++ b/src/export_drawsvg.py
@@ -5,9 +5,11 @@ from items import LineItem
 
 
 def export_drawsvg_py(scene: QtWidgets.QGraphicsScene, parent: QtWidgets.QWidget | None = None):
-    rect = scene.sceneRect()
+    rect = scene.itemsBoundingRect()
     width = int(rect.width())
     height = int(rect.height())
+    ox = int(rect.x())
+    oy = int(rect.y())
 
     items = [it for it in scene.items() if it.data(0) in SHAPES]
     items.reverse()
@@ -17,7 +19,7 @@ def export_drawsvg_py(scene: QtWidgets.QGraphicsScene, parent: QtWidgets.QWidget
     lines.append("import drawsvg as draw")
     lines.append("")
     lines.append("def build_drawing():")
-    lines.append(f"    d = draw.Drawing({width}, {height}, origin=(0, 0))")
+    lines.append(f"    d = draw.Drawing({width}, {height}, origin=({ox}, {oy}))")
     lines.append("")
 
     for it in items:

--- a/src/import_drawsvg.py
+++ b/src/import_drawsvg.py
@@ -76,9 +76,12 @@ def import_drawsvg_py(scene: QtWidgets.QGraphicsScene, parent: QtWidgets.QWidget
         for raw in lines:
             line = raw.strip()
             if line.startswith("d = draw.Drawing("):
-                args, _ = _parse_call(line)
+                args, kwargs = _parse_call(line)
                 if len(args) >= 2:
-                    scene.setSceneRect(0, 0, float(args[0]), float(args[1]))
+                    ox = oy = 0.0
+                    if "origin" in kwargs and isinstance(kwargs["origin"], (tuple, list)):
+                        ox, oy = map(float, kwargs["origin"][:2])
+                    scene.setSceneRect(float(ox), float(oy), float(args[0]), float(args[1]))
             elif line.startswith("_rect = draw.Rectangle("):
                 args, kwargs = _parse_call(line)
                 x, y, w, h = map(float, args[:4])


### PR DESCRIPTION
## Summary
- include item bounding rect and use its origin when generating draw.Drawing
- read drawing origin when importing drawsvg Python scripts

## Testing
- `python -m py_compile src/export_drawsvg.py src/import_drawsvg.py`
- `python - <<'PY' ...` *(fails: ImportError: libGL.so.1)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc837eeef083209c3bdb9485c0cb55